### PR TITLE
chore: update gatling-maven-plugin to v4.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <gatling.version>${project.version}</gatling.version>
-    <gatling-maven-plugin.version>4.0.1</gatling-maven-plugin.version>
+    <gatling-maven-plugin.version>4.1.0</gatling-maven-plugin.version>
     <maven-jar-plugin.version>3.2.0</maven-jar-plugin.version>
     <scala-maven-plugin.version>4.5.6</scala-maven-plugin.version>
   </properties>
@@ -62,6 +62,10 @@
         <groupId>io.gatling</groupId>
         <artifactId>gatling-maven-plugin</artifactId>
         <version>${gatling-maven-plugin.version}</version>
+        <configuration>
+          <!-- Enterprise Cloud (https://cloud.gatling.io/) configuration reference: https://gatling.io/docs/gatling/reference/current/extensions/maven_plugin/#working-with-gatling-enterprise-cloud -->
+          <!-- Enterprise Self-Hosted configuration reference: https://gatling.io/docs/gatling/reference/current/extensions/sbt_plugin/#working-with-gatling-enterprise-self-hosted -->
+        </configuration>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
**Modifications:**
* Update gatling-maven-plugin to 4.1.0
* Link enterprise & self-hosted configuration references

**Ref:** MISC-323