### PR TITLE
fix: specify Scala version in properties

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,7 @@
     <gatling-maven-plugin.version>4.1.5</gatling-maven-plugin.version>
     <maven-jar-plugin.version>3.2.0</maven-jar-plugin.version>
     <scala-maven-plugin.version>4.6.0</scala-maven-plugin.version>
+    <scala.version>2.13.8</scala.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
Build tools like [Bloop](https://scalacenter.github.io/bloop/) (used by [Metals](https://scalameta.org/metals/)) fail to compile unless the Scala version is explicitly specified.
See https://github.com/scalameta/metals/issues/2954 for details.